### PR TITLE
fix: preserve DKMH results when reopening periods

### DIFF
--- a/server/src/controllers/dkmhController.js
+++ b/server/src/controllers/dkmhController.js
@@ -175,7 +175,7 @@ export const getPeriodDetails = async (req, res) => {
         res.json({
             success: true,
             data: {
-                courses: parser.parsePeriodDetailsHtml(ketQuaHtml).courses,
+                courses: parser.parsePeriodDetailsHtml(ketQuaHtml),
                 schedule: parser.parseScheduleHtml(lichHtml),
                 periodId, dotDKId
             }

--- a/server/tests/controllers/dkmhController.test.js
+++ b/server/tests/controllers/dkmhController.test.js
@@ -8,6 +8,7 @@ jest.unstable_mockModule('../../src/services/sessionStore.js', () => ({
 
 jest.unstable_mockModule('../../src/services/dkmhParser.js', () => ({
     parseSearchResultsHtml: jest.fn(() => []),
+    parseScheduleHtml: jest.fn(() => ({ from: '', to: '', isOpen: true })),
     parsePeriodDetailsHtml: jest.fn(() => ({ courses: [], totalCredits: 0, totalCourses: 0 }))
 }));
 
@@ -29,6 +30,7 @@ jest.unstable_mockModule('fetch-cookie', () => ({
 
 const { activePeriodJars } = await import('../../src/services/sessionStore.js');
 const parser = await import('../../src/services/dkmhParser.js');
+const fetchCookie = await import('fetch-cookie');
 const dkmhController = await import('../../src/controllers/dkmhController.js');
 
 describe('dkmhController', () => {
@@ -53,6 +55,38 @@ describe('dkmhController', () => {
         activePeriodJars.set('token-123_period-1', {
             fetch: mockFetch,
             baseHeaders: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' }
+        });
+        fetchCookie.default.mockReturnValue(mockFetch);
+    });
+
+    describe('getPeriodDetails', () => {
+        it('should return full registration result summary for reopened D1 periods', async () => {
+            const registrationResult = {
+                courses: [{ code: 'CO3005', ketquaId: 'draft-1' }],
+                totalCredits: 4,
+                totalCourses: 1
+            };
+            req.session = { dkmhCookie: 'JSESSIONID=abc' };
+            req.body = { periodId: '685' };
+            mockFetch
+                .mockResolvedValueOnce({ text: jest.fn().mockResolvedValue('') })
+                .mockResolvedValueOnce({ text: jest.fn().mockResolvedValue('getLichDangKyByDotDKId(this, 767, 767)') })
+                .mockResolvedValueOnce({ text: jest.fn().mockResolvedValue('<input id="hdTrongHanDK" value="true" />') })
+                .mockResolvedValueOnce({ text: jest.fn().mockResolvedValue('') })
+                .mockResolvedValueOnce({ text: jest.fn().mockResolvedValue('<html>d1 draft result</html>') });
+            parser.parsePeriodDetailsHtml.mockReturnValue(registrationResult);
+
+            await dkmhController.getPeriodDetails(req, res);
+
+            expect(parser.parsePeriodDetailsHtml).toHaveBeenCalledWith('<html>d1 draft result</html>');
+            expect(res.json).toHaveBeenCalledWith({
+                success: true,
+                data: expect.objectContaining({
+                    courses: registrationResult,
+                    periodId: '685',
+                    dotDKId: '767'
+                })
+            });
         });
     });
 

--- a/src/features/registration/components/PeriodDetailsView.jsx
+++ b/src/features/registration/components/PeriodDetailsView.jsx
@@ -305,6 +305,14 @@ export default function PeriodDetailsView({ period, details, loading, onBack }) 
         await saveTemplate({ ...currentTemplate, courses: nextCourses });
     };
 
+    const handleDeleteTemplateCourse = async (courseToDelete) => {
+        if (!template) return;
+        const nextCourses = (template.courses || []).filter((course) => (
+            course.code !== courseToDelete.code && String(course.monHocId || "") !== String(courseToDelete.monHocId || "")
+        ));
+        await saveTemplate({ ...template, courses: nextCourses });
+    };
+
     const handleRunTemplate = async () => {
         if (!template?.id) return;
         if (findTemplateScheduleConflicts(template).length > 0) {
@@ -541,6 +549,7 @@ export default function PeriodDetailsView({ period, details, loading, onBack }) 
                     schedulingJob={schedulingJob}
                     onRun={handleRunTemplate}
                     onDelete={handleDeleteTemplate}
+                    onDeleteCourse={handleDeleteTemplateCourse}
                     autoSchedulerEnabled={autoSchedulerEnabled}
                     onCreateScheduledJob={handleCreateScheduledJob}
                     onDeleteScheduledJob={handleDeleteScheduledJob}

--- a/src/features/registration/components/RegistrationTemplatePanel.jsx
+++ b/src/features/registration/components/RegistrationTemplatePanel.jsx
@@ -26,6 +26,7 @@ export default function RegistrationTemplatePanel({
     autoSchedulerEnabled,
     onRun,
     onDelete,
+    onDeleteCourse,
     onCreateScheduledJob,
     onDeleteScheduledJob,
     onRunDueScheduledJobs
@@ -269,8 +270,22 @@ export default function RegistrationTemplatePanel({
                 <div className="mt-3 space-y-2">
                     {courses.map((course) => (
                         <div key={course.code || course.monHocId} className="rounded-xl bg-white/70 p-3 text-xs dark:bg-slate-950/30">
-                            <div className="font-semibold text-cyan-900 dark:text-cyan-200">
-                                {course.code} {course.name ? `• ${course.name}` : ""}
+                            <div className="flex items-start justify-between gap-2">
+                                <div className="font-semibold text-cyan-900 dark:text-cyan-200">
+                                    {course.code} {course.name ? `• ${course.name}` : ""}
+                                </div>
+                                {onDeleteCourse && (
+                                    <Button
+                                        size="sm"
+                                        variant="ghost"
+                                        className="h-6 w-6 shrink-0 p-0 text-red-500 hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-950/30"
+                                        disabled={saving || running || schedulingJob}
+                                        onClick={() => onDeleteCourse(course)}
+                                        title="Xóa môn khỏi mẫu"
+                                    >
+                                        <Trash2 className="h-3 w-3" />
+                                    </Button>
+                                )}
                             </div>
                             <div className="mt-1 flex flex-wrap gap-1">
                                 {(course.priority || []).map((item, index) => {


### PR DESCRIPTION
Return the full registration result summary from period details and allow removing individual courses from saved templates.